### PR TITLE
Update AZ-204_lab_04.md

### DIFF
--- a/Instructions/Labs/AZ-204_lab_04.md
+++ b/Instructions/Labs/AZ-204_lab_04.md
@@ -285,7 +285,7 @@ Dans cet exercice, vous avez créé les ressources Azure dont vous aurez besoin 
 
 Dans cet exercice, vous avez utilisé le Kit de développement logiciel (SDK).NET pour Azure Cosmos DB pour insérer des données dans Azure Cosmos DB. L’application web que vous allez implémenter ensuite utilisera ces données.
 
-### Exercice 3 : Configurer une application web.NET
+### Exercice 3 : Configurer une application web .NET
 
 #### Tâche 1 : Mettre à jour les références aux magasins de données et générer l’application web
 
@@ -328,7 +328,7 @@ Dans cet exercice, vous avez utilisé le Kit de développement logiciel (SDK).NE
     dotnet add package Microsoft.Azure.Cosmos --version 3.28.0
     ```
 
-1.  À partir de l’invite du terminal, exécutez la commande suivante pour générer l’application web.NET :
+1.  À partir de l’invite du terminal, exécutez la commande suivante pour générer l’application web .NET :
 
     ```
     dotnet build
@@ -484,7 +484,7 @@ Dans cet exercice, vous avez utilisé le Kit de développement logiciel (SDK).NE
 
 1.  Enregistrez et fermez le fichier **AdventureWorksCosmosContext.cs**.
    
-1.  À partir de l’invite du terminal, avec le répertoire actif défini sur **AdventureWorks.Context**, exécutez la commande suivante pour générer l’application web.NET:
+1.  À partir de l’invite du terminal, avec le répertoire actif défini sur **AdventureWorks.Context**, exécutez la commande suivante pour générer l’application web .NET:
 
     ```
     dotnet build
@@ -523,7 +523,7 @@ Dans cet exercice, vous avez utilisé le Kit de développement logiciel (SDK).NE
     cd ..\AdventureWorks.Web\
     ```
 
-1.  À partir de l’invite du terminal, exécutez la commande suivante afin d’exécuter l’application web.NET :
+1.  À partir de l’invite du terminal, exécutez la commande suivante afin d’exécuter l’application web .NET :
 
     ```
     dotnet run


### PR DESCRIPTION
Removed space between 'web' and '.NET'
web.NET -> web .NET

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

- Not sure how this happened, but a space was missing between the word 'web' and the word '.NET' throught the page. I've added the missing space
-
-